### PR TITLE
Calculate arch from the actual size of a void*

### DIFF
--- a/discord/ext/copus/copus.py
+++ b/discord/ext/copus/copus.py
@@ -1,4 +1,5 @@
 import os
+import struct
 import sys
 import logging
 
@@ -8,7 +9,7 @@ log = logging.getLogger(__name__)
 
 # Fix PATH on windows
 if sys.platform == 'win32':
-    _arch = '64' if sys.maxsize > 2**32 else '32'
+    _arch = struct.calcsize('P') * 8
     _basepath = os.path.dirname(__file__)
     _binpath = os.path.abspath(os.path.normpath(os.path.join(_basepath, 'bin', f'x{_arch}')))
     log.info("Adding %r to os.environ['PATH']", _binpath)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
-import sys
 import shutil
+import struct
+import sys
 
 from os.path import normpath as norm
 
@@ -12,7 +13,7 @@ os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'discord', 'ex
 
 # System info
 platform = sys.platform
-arch = '64' if sys.maxsize > 2**32 else '32'
+arch = struct.calcsize('P') * 8
 
 # Defaults
 bindir = norm(os.path.join(os.path.abspath('.'), 'bin', f'x{arch}'))
@@ -36,7 +37,7 @@ if platform == 'win32':
     include_dirs.append(norm('D:/MinGW/include'))
     library_dirs.append(norm('D:/MinGW/lib'))
 
-    if arch == '64':
+    if arch == 64:
         extra_compile_args.append('-DMS_WIN64')
 
 setup(


### PR DESCRIPTION
This is the more reliable and typically-accepted method of determining architecture in pure-python.