### PR TITLE
Make PyPI-compatible manylinux wheels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@
 version: 2
 
 jobs:
-  "make stretch 3.6":
+  "make manylinux":
     docker:
-      - image: gorialis/discord.py:3.6-stretch-master
+      - image: quay.io/pypa/manylinux2010_x86_64
 
     working_directory: ~/repo
 
@@ -12,60 +12,22 @@ jobs:
       - checkout
 
       - run:
-          name: install Cython
+          name: install dependencies
           command: |
-            pip install -U Cython==0.27.3
+            yum install -y opus-devel
+            /opt/python/cp36-cp36m/bin/pip install -U Cython==0.27.3
+            /opt/python/cp37-cp37m/bin/pip install -U Cython==0.27.3
 
       - run:
           name: build distributions
           command: |
-            python ./setup.py bdist_egg bdist_wheel
-
-      - store_artifacts:
-          path: dist
-          destination: distributions
-
-  "make stretch 3.7":
-    docker:
-      - image: gorialis/discord.py:3.7-stretch-master
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
+            /opt/python/cp36-cp36m/bin/python ./setup.py bdist_egg bdist_wheel
+            /opt/python/cp37-cp37m/bin/python ./setup.py bdist_egg bdist_wheel
 
       - run:
-          name: install Cython
+          name: create manylinux wheel
           command: |
-            pip install -U Cython==0.27.3
-
-      - run:
-          name: build distributions
-          command: |
-            python ./setup.py bdist_egg bdist_wheel
-
-      - store_artifacts:
-          path: dist
-          destination: distributions
-
-  "make stretch 3.8":
-    docker:
-      - image: gorialis/discord.py:3.8-stretch-master
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      - run:
-          name: install Cython
-          command: |
-            pip install -U Cython==0.27.3
-
-      - run:
-          name: build distributions
-          command: |
-            python ./setup.py bdist_egg bdist_wheel
+            for whl in dist/*.whl; do auditwheel repair "$whl" --plat manylinux2010_x86_64 -w dist; done
 
       - store_artifacts:
           path: dist
@@ -75,6 +37,4 @@ workflows:
   version: 2
   build:
     jobs:
-      - "make stretch 3.6"
-      - "make stretch 3.7"
-      - "make stretch 3.8"
+      - "make manylinux"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,49 +1,18 @@
 
 stages:
   - build
-  - deploy
 
-make stretch 3.6:
+make manylinux:
   stage: build
-  image: gorialis/discord.py:3.6-stretch-master
+  image: quay.io/pypa/manylinux2010_x86_64
   before_script:
-    - pip install -U Cython==0.27.3
+    - yum install -y opus-devel
+    - /opt/python/cp36-cp36m/bin/pip install -U Cython==0.27.3
+    - /opt/python/cp37-cp37m/bin/pip install -U Cython==0.27.3
   script:
-    - python ./setup.py bdist_egg bdist_wheel
-  artifacts:
-    paths:
-      - dist
-    expire_in: 30 days
-
-make stretch 3.7:
-  stage: build
-  image: gorialis/discord.py:3.7-stretch-master
-  before_script:
-    - pip install -U Cython==0.27.3
-  script:
-    - python ./setup.py bdist_egg bdist_wheel
-  artifacts:
-    paths:
-      - dist
-    expire_in: 30 days
-
-make stretch 3.8:
-  stage: build
-  image: gorialis/discord.py:3.8-stretch-master
-  before_script:
-    - pip install -U Cython==0.27.3
-  script:
-    - python ./setup.py bdist_egg bdist_wheel
-  artifacts:
-    paths:
-      - dist
-    expire_in: 30 days
-
-accumulate distributions:
-  stage: deploy
-  image: gorialis/discord.py:3.8-stretch-master
-  script:
-    - ls dist
+    - /opt/python/cp36-cp36m/bin/python ./setup.py sdist bdist_egg bdist_wheel
+    - /opt/python/cp37-cp37m/bin/python ./setup.py bdist_egg bdist_wheel
+    - for whl in dist/*.whl; do auditwheel repair "$whl" --plat manylinux2010_x86_64 -w dist; done
   artifacts:
     paths:
       - dist


### PR DESCRIPTION
This updates GitLab and Circle CI to use the PyPA Centos 6 docker image to build manylinux wheels for 3.6 and 3.7.
This produces both a `manylinux1` and `manylinux2010` variant of both `linux` wheels that can be uploaded to PyPI.